### PR TITLE
增加 import 选项解析

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Change the `webpack.config.js` file.
 +         color: '#008000'
 +       },
 +       yellow: {
++         import: [
++           '~thirdpartylibrary/styles/yellow.less'
++         ],
 +         color: '#ffff00'
 +       }
 +     },

--- a/README_zh.md
+++ b/README_zh.md
@@ -55,6 +55,9 @@ module.exports = {
 +         color: '#008000'
 +       },
 +       yellow: {
++         import: [
++           '~thirdpartylibrary/styles/yellow.less'
++         ],
 +         color: '#ffff00'
 +       }
 +     },

--- a/src/generate-themes.js
+++ b/src/generate-themes.js
@@ -10,8 +10,13 @@ const write = function(pathLike, content) {
   fs.writeFileSync(pathLike, content, 'utf-8');
 };
 
+const getImportLines = config => {
+  const imports = config.import || [];
+  return _.map(imports, path => `@import '${path}';`);
+};
+
 const getModifyVariablesContent = variableConfig => {
-  const declaredContent = _.map(_.entries(variableConfig), ([key, value]) => `@${key}:${value};`);
+  const declaredContent = _.map(_.entries(variableConfig).filter(([key]) => key !== 'import'), ([key, value]) => `@${key}:${value};`);
   return declaredContent.join('\r');
 };
 
@@ -27,8 +32,9 @@ const generateThemes = (themesConfig = {}, configs = {}) => {
   _.forEach(_.entries(themesConfig), ([theme, config]) => {
     const lessFileName = `${theme}.less`;
     const jsFileName = `${theme}.js`;
+    const importLines = getImportLines(config);
     const modifyVariablesContent = getModifyVariablesContent(config);
-    const content = `${typeof lessContent === 'function' ? lessContent(theme, config) : lessContent}
+    const content = `${typeof lessContent === 'function' ? lessContent(theme, config) : [...importLines, lessContent].join('\r')}
 
 ${preHeader}
 ${modifyVariablesContent}`;

--- a/src/generate-themes.js
+++ b/src/generate-themes.js
@@ -34,7 +34,7 @@ const generateThemes = (themesConfig = {}, configs = {}) => {
     const jsFileName = `${theme}.js`;
     const importLines = getImportLines(config);
     const modifyVariablesContent = getModifyVariablesContent(config);
-    const content = `${typeof lessContent === 'function' ? lessContent(theme, config) : [...importLines, lessContent].join('\r')}
+    const content = `${typeof lessContent === 'function' ? lessContent(theme, config) : [...importLines, lessContent].join('\n')}
 
 ${preHeader}
 ${modifyVariablesContent}`;

--- a/test/generate-themes.test.js
+++ b/test/generate-themes.test.js
@@ -8,6 +8,12 @@ describe('Default generate.', () => {
   generateThemes({
     red: {
       'base-color': '#ff0000'
+    },
+    dark: {
+      import: [
+        '~rsuite/lib/styles/themes/dark/index'
+      ],
+      color: '#e5e5e5'
     }
   });
   const outPutFilePath = path.resolve(process.cwd(), './src/src/less/themes');
@@ -34,6 +40,16 @@ import './red.less';`
 @base-color:#ff0000;`
     );
   });
+
+  test('dark.less import validate', () => {
+    expect(readFile(resolvePath('dark.less'))).toEqual(
+      `@import '~rsuite/lib/styles/themes/dark/index';
+@import "../index";
+
+// Generate by Script.
+@color:#e5e5e5;`
+    );
+  })
 });
 
 describe('Multiple themes generate.', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -60,7 +60,7 @@ test('Output Name test', done => {
   });
   runCompiler(compiler).then(() => {
     const dist = fs.readdirSync(`${outputPath}/css`);
-    expect(dist.length).toEqual(3);
+    expect(dist.length).toEqual(4);
     expect(dist).toContain('theme-green.css');
     expect(dist).toContain('theme-yellow.css');
     expect(dist).toContain('theme-red.css');

--- a/test/themes.config.js
+++ b/test/themes.config.js
@@ -7,5 +7,8 @@ module.exports = {
   },
   red: {
     color: '#ff0000'
+  },
+  dark: {
+    color: '#e5e5e5'
   }
 };


### PR DESCRIPTION
主题配置增加 import 数组选项，表示需要引入的 LESS 文件。既支持了导入第三方库的 LESS 文件，也修复了配置中的 import 字段被处理成 @import 变量导致编译出错的问题。